### PR TITLE
更改文件包含

### DIFF
--- a/DesignPatterns.Observer/Observer.cpp
+++ b/DesignPatterns.Observer/Observer.cpp
@@ -4,10 +4,12 @@
 DesignPatterns_Observer::IObserver::~IObserver()
 {
 	//可观察对象的指针应该由其自己维护
-	/*if (subject != nullptr)
-			{
-			delete subject;
-			}*/
+	/*
+	if (subject != nullptr)
+	{
+		delete subject;
+	}
+	*/
 }
 
 DesignPatterns_Observer::IObserver::IObserver(ISubject* subj)

--- a/DesignPatterns.Observer/Observer.h
+++ b/DesignPatterns.Observer/Observer.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "Subject.h"
-
 namespace DesignPatterns_Observer
 {
+	//前置声明
+	class ISubject;
+
 	/*
 	 *观察者
 	 */

--- a/DesignPatterns.Observer/Subject.h
+++ b/DesignPatterns.Observer/Subject.h
@@ -1,11 +1,12 @@
 #pragma once
 
 #include <list>   
-using std::list;
 
 namespace DesignPatterns_Observer
 {
+	//类型前置声明
 	class IObserver;
+
 	/*
 	 *可观察对象
 	 */
@@ -13,7 +14,7 @@ namespace DesignPatterns_Observer
 	{
 	private:
 		//存储观察者对象指针
-		list<IObserver*> Observers;
+		std::list<IObserver*> Observers;
 
 	public:
 		ISubject();

--- a/DesignPatterns.Observer/WeatherData.cpp
+++ b/DesignPatterns.Observer/WeatherData.cpp
@@ -11,7 +11,7 @@ CWeatherData::CWeatherData()
 
 CWeatherData::~CWeatherData()
 {
-iostream:std::cout << "\t\t==释放天气对象." << std::endl;
+	std::cout << "\t\t==释放天气对象." << std::endl;
 }
 
 void CWeatherData::measurementsChanged()


### PR DESCRIPTION
观察者和被观察对象的头文件存在相互包含的问题，通过使用前值声明解决。
